### PR TITLE
Check de consistência de dados

### DIFF
--- a/stress-test/user-files/simulations/rinhabackend/RinhaBackendSimulation.scala
+++ b/stress-test/user-files/simulations/rinhabackend/RinhaBackendSimulation.scala
@@ -23,16 +23,18 @@ class RinhaBackendSimulation
       // 422 pra requests inválidos :|
       // 400 pra requests bosta tipo data errada, tipos errados, etc. :(
       .check(status.in(201, 422, 400))
-      .check(header("Location").optional.saveAs("location"))
+      // Se a criacao foi na api1 e esse location request atingir api2, a api2 tem que encontrar o registro.
+      // Pode ser que o request atinga a mesma instancia, mas estatisticamente, pelo menos um request vai atingir a outra.
+      // Isso garante o teste de consistencia de dados
+      .checkIf(session => session("httpStatus").as[String] == "201") {
+        header("Location").saveAs("location")
+      }
     )
     .pause(1.milliseconds, 30.milliseconds)
     .doIf(session => session.contains("location")) {
       exec(
         http("consulta")
         .get("#{location}")
-        // Se a criacao foi na api1 e esse location request atingir api2, a api2 tem que encontrar o registro.
-        // Pode ser que um request atinga a api1, mas estatisticamente, pelo menos um request vai atingir a api2.
-        .check(status.is(200))
       )
     }
 

--- a/stress-test/user-files/simulations/rinhabackend/RinhaBackendSimulation.scala
+++ b/stress-test/user-files/simulations/rinhabackend/RinhaBackendSimulation.scala
@@ -30,6 +30,9 @@ class RinhaBackendSimulation
       exec(
         http("consulta")
         .get("#{location}")
+        // Se a criacao foi na api1 e esse location request atingir api2, a api2 tem que encontrar o registro.
+        // Pode ser que um request atinga a api1, mas estatisticamente, pelo menos um request vai atingir a api2.
+        .check(status.is(200))
       )
     }
 


### PR DESCRIPTION
Quando o cenário "Criação E Talvez Consulta de Pessoas" é executado, o teste de `consulta` não é executado quando o header não existe, pois o código usa `optional`.

Isso faz com que muitas implementações deixam de executar a busca pelo registro criado logo após o insert. Com isso, algumas implementações conseguiam atingir elevados resultados de rps.

Com esta PR, o teste exige que o Location esteja presente para resultados `201` e que a consulta pelo mesmo registro recentemente inserido, sempre retorne `200`, independente de qual instância de API é atingida.

Estatisticamente, pelo menos 1 request irá atingir a outra instância. Isso faz com que as implementações tenham que garantir consistência de dados a qualquer momento.