### PR TITLE
chore:update EuFountai

### DIFF
--- a/participantes/EuFountai/README.md
+++ b/participantes/EuFountai/README.md
@@ -9,9 +9,7 @@ Github Repository: [@Eletroswing/rinha-de-backend-2023](https://github.com/eletr
  - Javascript
  - Postgres
  - socket as pub-sub
- - Custom http module
-  > Uses an updated and edited version of the quarkhttp project
-  > https://github.com/softchris/mini-web
+ - Antiga versão usava http, mas endoidei e fiz minha própria versão de conexão tcp descrita em [Nodejs: Construindo Comunicação TCP Pura Sem HTTP ou Net, Apenas por Diversão! ☕](https://www.tabnews.com.br/Ytu/nodejs-construindo-comunicacao-tcp-pura-sem-http-ou-net-apenas-por-diversao)
 
 
 # Feito a base de ☕

--- a/participantes/EuFountai/docker-compose.yml
+++ b/participantes/EuFountai/docker-compose.yml
@@ -20,9 +20,6 @@ services:
       POSTGRES_PASSWORD: mypassword
       POSTGRES_USER: myuser
       POSTGRES_HOST: database
-      REDIS_PORT: 6379
-      REDIS_HOST: redis
-      WS_NAME: api1
       WS: ws://pubsub:8080
     deploy:
       resources:
@@ -50,9 +47,6 @@ services:
       POSTGRES_PASSWORD: mypassword
       POSTGRES_USER: myuser
       POSTGRES_HOST: database
-      REDIS_PORT: 6379
-      REDIS_HOST: redis
-      WS_NAME: api2
       WS: ws://pubsub:8080
     deploy:
       resources:

--- a/participantes/EuFountai/docker-compose.yml
+++ b/participantes/EuFountai/docker-compose.yml
@@ -56,6 +56,8 @@ services:
 
   pubsub:
     image: eufountai/socket-pubsub:latest
+    expose:
+      - '8080'
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Antiga versão usava http, mas endoidei e fiz minha própria versão de conexão tcp descrita em [Nodejs: Construindo Comunicação TCP Pura Sem HTTP ou Net, Apenas por Diversão! ☕](https://www.tabnews.com.br/Ytu/nodejs-construindo-comunicacao-tcp-pura-sem-http-ou-net-apenas-por-diversao)