### PR TITLE
add oliveigah files

### DIFF
--- a/participantes/oliveigah/README.md
+++ b/participantes/oliveigah/README.md
@@ -1,0 +1,15 @@
+# Overview
+
+Implementação utilizando elixir + nginx + postgres
+
+Utilizei um esquema de cache consistente para evitar ao maximo chamadas ao banco de dados.
+
+Utilizando distributed erlang é garantido que todas as chamadas para o mesmo id serão processadas pelo mesmo node da aplicação.
+
+Sendo assim, quando o registro é escrito no banco também é escrito na memoria do nó responsável por ele.
+
+Com isso consigo garantir que caso o registro não seja encontrado no cache do nó responsável ele tambem não existe no banco.
+
+Essa estrategia precisa ser adaptada para caso os nós possam sofrer restarts, para repopular o cache e afins, mas não me preocupei com isso por agora.
+
+Repo: https://github.com/oliveigah/rinha_backend

--- a/participantes/oliveigah/docker-compose.yml
+++ b/participantes/oliveigah/docker-compose.yml
@@ -1,0 +1,75 @@
+version: '3.5'
+services:
+  database:
+    image: postgres:latest
+    command: postgres -c 'max_connections=250'
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=pass
+      - POSTGRES_DB=rinha_backend
+    ports:
+      - 5432:5432
+    volumes:
+      - database:/var/lib/postgresql/data
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: '1GB'
+
+  api1:
+    image: oliveigah/rinha-backend:with_postgres_nginx_v2
+    depends_on:
+      - database
+    hostname: api1.com
+    environment:
+      HTTP_SERVER_PORT: 3000
+      RELEASE_COOKIE: "secret_cookie"
+      RELEASE_NODE: "api@api1.com"
+      RELEASE_DISTRIBUTION: "name"
+      BOOTSTRAP_NODES: "api@api2.com"
+    healthcheck:
+      test: curl -f http://api1:3000
+    deploy:
+      resources:
+        limits:
+          cpus: '0.4'
+          memory: '0.75GB'
+
+
+  api2:
+    image: oliveigah/rinha-backend:with_postgres_nginx_v2
+    depends_on:
+      - api1
+    hostname: api2.com
+    environment:
+      HTTP_SERVER_PORT: 3000
+      RELEASE_COOKIE: "secret_cookie"
+      RELEASE_NODE: "api@api2.com"
+      RELEASE_DISTRIBUTION: "name"
+      BOOTSTRAP_NODES: "api@api1.com"
+    healthcheck:
+      test: curl -f http://api2:3000
+    deploy:
+      resources:
+        limits:
+          cpus: '0.4'
+          memory: '0.75GB'
+
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - api1
+      - api2
+    ports:
+      - "3000:9999"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.2'
+          memory: '0.5GB'
+
+volumes:
+  database:

--- a/participantes/oliveigah/docker-compose.yml
+++ b/participantes/oliveigah/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - api1
       - api2
     ports:
-      - "3000:9999"
+      - "9999:9999"
     deploy:
       resources:
         limits:

--- a/participantes/oliveigah/nginx.conf
+++ b/participantes/oliveigah/nginx.conf
@@ -1,0 +1,13 @@
+events {}
+http {
+    upstream api {
+        server api1:3000;
+        server api2:3000;
+    }
+    server {
+        listen 9999;
+        location / {
+            proxy_pass http://api;
+        }
+    }
+}


### PR DESCRIPTION
Refiz a implementação agora seguindo mais as regras! 🤣

O unico ponto que fiquei na duvida se eu estava burlando foi:

Eu usei um esquema de cache consistente para não precisar consultar o banco caso não encontre o registro no cache da aplicação. Toda requisição é sempre direcionada para o mesmo nó de acordo com um hash do dado de entrada.

Sendo assim, toda escrita no banco é também escrita no cache do nó e como toda requisição para esse registro vai para esse nó por conta do hashing posso olhar só para o cache em todas as requsições de leitura.

De toda forma os dados são persistidos no postgres também e o postgres é usado para a rota de busca textual.

Acredito que assim seja mais justo, se achar que esse esquema de cache não é valido só falar que ajusto aqui. 😄