### PR TITLE
Update MrPowerGamerBR's entry

### DIFF
--- a/participantes/MrPowerGamerBR/docker-compose.yml
+++ b/participantes/MrPowerGamerBR/docker-compose.yml
@@ -2,43 +2,32 @@ version: '3.5'
 services:
   rinha1:
     hostname: "rinha1"
-    image: ghcr.io/mrpowergamerbr/rinha-de-backend-2023-q3@sha256:160373fff01b74891c613a06917859ecf845308819badc4466bd3777bd42bf93
+    image: ghcr.io/mrpowergamerbr/rinha-de-backend-2023-q3@sha256:d50541cc9b9c0e81a802be47ac7d99d77e86eaaa8c6ce75c531935b972804fd3
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: [ "CMD-SHELL", "curl 127.0.0.1:9999" ]
+      interval: 3s
+      timeout: 5s
+      retries: 10
     environment:
       POSTGRESQL_ADDRESS: db
       POSTGRESQL_USERNAME: postgres
       POSTGRESQL_PASSWORD: postgres
       POSTGRESQL_DATABASE: rinhadebackend
+      POSTGRESQL_TRGM: true
+      PUDDING_POOL_SIZE: 4
+      PUDDING_PERMITS: 32
+      RINHA_ENABLE_SEARCH: true
       WEBSERVER_PORT: 9999
-      JAVA_TOOL_OPTIONS: "-verbose:gc -XX:+UnlockExperimentalVMOptions -Xmx768M -Xmx768M -XX:+UseG1GC -XX:+AlwaysPreTouch -XX:+ExitOnOutOfMemoryError"
+      WEBSERVER_ENGINE: "cio"
+      JAVA_TOOL_OPTIONS: "-verbose:gc -XX:+UnlockExperimentalVMOptions -Xmx768M -Xmx768M -XX:+UseG1GC -XX:+AlwaysPreTouch -XX:+ExitOnOutOfMemoryError -Dkotlinx.coroutines.io.parallelism=256"
     deploy:
       resources:
         limits:
-          cpus: '0.25'
-          memory: '768MB'
-    networks:
-      - rinha-network
-
-  rinha2:
-    hostname: "rinha2"
-    image: ghcr.io/mrpowergamerbr/rinha-de-backend-2023-q3@sha256:160373fff01b74891c613a06917859ecf845308819badc4466bd3777bd42bf93
-    depends_on:
-      db:
-        condition: service_healthy
-    environment:
-      POSTGRESQL_ADDRESS: db
-      POSTGRESQL_USERNAME: postgres
-      POSTGRESQL_PASSWORD: postgres
-      POSTGRESQL_DATABASE: rinhadebackend
-      WEBSERVER_PORT: 9999
-      JAVA_TOOL_OPTIONS: "-verbose:gc -XX:+UnlockExperimentalVMOptions -Xmx768M -Xmx768M -XX:+UseG1GC -XX:+AlwaysPreTouch -XX:+ExitOnOutOfMemoryError"
-    deploy:
-      resources:
-        limits:
-          cpus: '0.25'
-          memory: '768MB'
+          cpus: '0.6'
+          memory: '1024MB'
     networks:
       - rinha-network
 
@@ -47,10 +36,9 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.75'
-          memory: '1280MB'
+          cpus: '0.85'
+          memory: '1792MB'
     environment:
-      PGUSER: postgres
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: rinhadebackend
@@ -59,11 +47,19 @@ services:
       interval: 3s
       timeout: 5s
       retries: 10
+    volumes:
+      - type: bind
+        source: init.sh
+        target: /docker-entrypoint-initdb.d/init-extension.sh
+    command: "postgres -c max_connections=200 -c shared_buffers=512MB -c effective_cache_size=1536MB -c maintenance_work_mem=128MB -c checkpoint_completion_target=0.9 -c wal_buffers=16MB -c default_statistics_target=100 -c random_page_cost=1.1 -c effective_io_concurrency=200 -c work_mem=1310kB -c huge_pages=off -c min_wal_size=1GB -c max_wal_size=4GB"
     networks:
       - rinha-network
 
   nginx: # Load Balancer
     image: nginx:latest
+    depends_on:
+      rinha1:
+        condition: service_healthy
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
@@ -71,7 +67,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.25'
+          cpus: '0.05'
           memory: '256MB'
     networks:
       - rinha-network

--- a/participantes/MrPowerGamerBR/init.sh
+++ b/participantes/MrPowerGamerBR/init.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+	CREATE EXTENSION pg_trgm;
+EOSQL

--- a/participantes/MrPowerGamerBR/nginx.conf
+++ b/participantes/MrPowerGamerBR/nginx.conf
@@ -1,10 +1,8 @@
 events {
-    # configure como quiser
 }
 http {
     upstream api {
         server rinha1:9999;
-        server rinha2:9999;
     }
     server {
         listen 9999;


### PR DESCRIPTION
Eu sei, eu sei, o evento já acabou, eu acabei revendo a minha entry pois [eu descobri que a minha implementação não deu certo](https://twitter.com/MrPowerGamerBR/status/1695566587040817181) então eu acabei melhorando ela. Criei o pull request para "pessoas futuras que vierem aqui ver todos que enviaram".

(Eu não sei porque não funcionou, mas eu percebi que, as vezes, tem chance do container do nginx iniciar antes da API da rinha e aí o nginx sai com um erro pois o hostname da API não existe)

**As mudanças que foram feitas:**
* Otimização no insert de pessoas, evitando o máximo roundtrips ao PostgreSQL
* Agora só tem um servidor de API ao invés de dois, assim evitando o overhead de memória que custa duas JVMs
* A API e a Database agora foram balanceados de forma melhor, assim evitando ao máximo que o throughput diminua devido a bottleneck em alguma das duas partes
* PostgreSQL agora tem a extensão de `pg_trgm` instalada e com indexes GiST criados no nome/apelido das pessoas e no nome dos stacks

Com as mudanças e as otimizações que eu fiz, a implementação foi de míseras 6526 pessoas para 19434 pessoas, nada mal para uma implementação feita com muita preguiça :3

**Antes:**

<img width="1127" alt="WindowsTerminal_W7gbzoDumI" src="https://github.com/zanfranceschi/rinha-de-backend-2023-q3/assets/9496359/8f7171e6-91e8-47f8-9684-c88830f1ee03">

**Depois:**

<img width="1114" alt="WindowsTerminal_ywFy7noEcg" src="https://github.com/zanfranceschi/rinha-de-backend-2023-q3/assets/9496359/2cfa849a-be28-41f8-8628-ac26c5b148de">

